### PR TITLE
Refactor errors

### DIFF
--- a/src/Error/InvalidArgumentError.js
+++ b/src/Error/InvalidArgumentError.js
@@ -7,15 +7,18 @@
  * file that was distributed with this source code.
  */
 
+import SerializerError from './SerializerError';
+
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-export default class UnexpectedTypeError extends Error {
-    constructor(message) {
+export default class InvalidArgumentError extends SerializerError {
+    /**
+     * @param {string} [message='']
+     */
+    constructor(message = '') {
         super(message);
 
-        this.name = this.constructor.name;
-        this.message = message;
-        Error.captureStackTrace(this, this.constructor.name);
+        this.name = 'InvalidArgumentError';
     }
 }

--- a/src/Error/SerializerError.js
+++ b/src/Error/SerializerError.js
@@ -7,20 +7,25 @@
  * file that was distributed with this source code.
  */
 
-import SerializerError from './SerializerError';
-
 /**
- * Error thrown upon (de-)serialization process.
+ * Root error for the serializer.
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-export default class SerializationError extends SerializerError {
+export default class SerializerError extends Error {
     /**
      * @param {string} [message='']
      */
     constructor(message = '') {
         super(message);
 
-        this.name = 'SerializationError';
+        this.name = 'SerializerError';
+        this.message = message;
+
+        if (Error.hasOwnProperty('captureStackTrace')) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.stack = (new Error(message)).stack;
     }
 }

--- a/src/Error/UnimplementedMethodError.js
+++ b/src/Error/UnimplementedMethodError.js
@@ -7,15 +7,18 @@
  * file that was distributed with this source code.
  */
 
+import SerializerError from './SerializerError';
+
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-export default class UnimplementedSerializerMethodError extends Error {
-    constructor(message) {
+export default class UnimplementedSerializerMethodError extends SerializerError {
+    /**
+     * @param {string} [message='']
+     */
+    constructor(message = '') {
         super(message);
 
-        this.name = this.constructor.name;
-        this.message = message;
-        Error.captureStackTrace(this, this.constructor.name);
+        this.name = 'UnimplementedMethodError';
     }
 }

--- a/src/Serializer/Serializer.js
+++ b/src/Serializer/Serializer.js
@@ -10,7 +10,7 @@
 import SerializerAware from './SerializerAware';
 import SerializerInterface from './SerializerInterface';
 import SerializationError from './../Error/SerializationError';
-import UnexpectedTypeError from './../Error/UnexpectedTypeError';
+import InvalidArgumentError from './../Error/InvalidArgumentError';
 
 /**
  * Default serializer.
@@ -23,13 +23,15 @@ import UnexpectedTypeError from './../Error/UnexpectedTypeError';
 export default class Serializer extends SerializerInterface {
     /**
      * @param {Map.<string,SerializerInterface>} serializers
+     *
+     * @throw InvalidArgumentError
      */
     constructor(serializers) {
         super(serializers);
 
         for (const serializer of serializers.values()) {
             if (false === serializer instanceof SerializerInterface) {
-                throw new UnexpectedTypeError(
+                throw new InvalidArgumentError(
                     `Expected serializer to implement SerializerInterface. Got ${serializer.constructor} instead`
                 );
             }

--- a/src/Serializer/SerializerInterface.js
+++ b/src/Serializer/SerializerInterface.js
@@ -8,7 +8,7 @@
  */
 
 import SerializationError from './../Error/SerializationError';
-import UnimplementedSerializerMethodError from './../Error/UnimplementedSerializerMethodError';
+import UnimplementedMethodError from './../Error/UnimplementedMethodError';
 
 /**
  * A serializer is responsible for transforming a data in a specific format into a data in another format.
@@ -38,7 +38,7 @@ export default class SerializerInterface {
      * @throw SerializationError
      */
     serialize(data, format, context) {
-        throw new UnimplementedSerializerMethodError('Unimplemented "serialize()" method');
+        throw new UnimplementedMethodError('Unimplemented "serialize()" method');
     }
 
     /**
@@ -50,7 +50,7 @@ export default class SerializerInterface {
      * @return {boolean}
      */
     supportsSerialize(data, format = null) {
-        throw new UnimplementedSerializerMethodError('Unimplemented "supportsSerialize()" method');
+        throw new UnimplementedMethodError('Unimplemented "supportsSerialize()" method');
     }
 
     /**
@@ -65,7 +65,7 @@ export default class SerializerInterface {
      * @throw SerializationError
      */
     deserialize(data, className, format = null, context = null) {
-        throw new UnimplementedSerializerMethodError('Unimplemented "deserialize()" method');
+        throw new UnimplementedMethodError('Unimplemented "deserialize()" method');
     }
 
     /**
@@ -78,6 +78,6 @@ export default class SerializerInterface {
      * @return {boolean}
      */
     supportsDeserialize(data, className, format = null) {
-        throw new UnimplementedSerializerMethodError('Unimplemented "supportsDeserialize()" method');
+        throw new UnimplementedMethodError('Unimplemented "supportsDeserialize()" method');
     }
 }

--- a/src/serializerjs.js
+++ b/src/serializerjs.js
@@ -7,9 +7,10 @@
  * file that was distributed with this source code.
  */
 
+import InvalidArgumentError from './Error/InvalidArgumentError';
 import SerializationError from './Error/SerializationError';
-import UnexpectedTypeError from './Error/UnexpectedTypeError';
-import UnimplementedSerializerMethodError from './Error/UnimplementedSerializerMethodError';
+import SerializerError from './Error/SerializerError';
+import UnimplementedMethodError from './Error/UnimplementedMethodError';
 
 import AbstractSerializer from './Serializer/AbstractSerializer';
 import Serializer from './Serializer/Serializer';
@@ -27,12 +28,14 @@ class SerializerFactory {
     }
 }
 
+/** @type {InvalidArgumentError} */
+SerializerFactory.InvalidArgumentError = InvalidArgumentError;
 /** @type {SerializationError} */
 SerializerFactory.SerializationError = SerializationError;
-/** @type {UnexpectedTypeError} */
-SerializerFactory.UnexpectedTypeError = UnexpectedTypeError;
+/** @type {SerializerError} */
+SerializerFactory.SerializerError = SerializerError;
 /** @type {UnimplementedSerializerMethodError} */
-SerializerFactory.UnimplementedSerializerMethodError = UnimplementedSerializerMethodError;
+SerializerFactory.UnimplementedSerializerMethodError = UnimplementedMethodError;
 
 /** @type {AbstractSerializer} */
 SerializerFactory.AbstractSerializer = AbstractSerializer;

--- a/tests/Error/InvalidArgumentErrorErrorTest.js
+++ b/tests/Error/InvalidArgumentErrorErrorTest.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the serializerjs package.
+ *
+ * (c) HAIRCVT <tfidry@haircvt.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/* eslint-env mocha */
+
+import { assert } from 'chai';
+
+import SerializerError from './../../src/Error/SerializerError';
+import InvalidArgumentError from './../../src/Error/InvalidArgumentError';
+
+/** @test {InvalidArgumentError} */
+describe('SerializationError', () => {
+    it('It is a SerializerError', () => {
+        assert.isTrue(InvalidArgumentError.prototype instanceof SerializerError);
+    });
+
+    it('Its name is an InvalidArgumentError error', () => {
+        const error = new InvalidArgumentError();
+        assert.strictEqual(error.name, 'InvalidArgumentError');
+    });
+});

--- a/tests/Error/SerializationErrorTest.js
+++ b/tests/Error/SerializationErrorTest.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the JsSerializer package.
+ *
+ * (c) HAIRCVT <hello@haircvt.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/* eslint-env mocha */
+
+import { assert } from 'chai';
+
+import SerializationError from './../../src/Error/SerializationError';
+import SerializerError from './../../src/Error/SerializerError';
+
+/** @test {SerializationError} */
+describe('SerializationError', () => {
+    it('It is a SerializerError', () => {
+        assert.isTrue(SerializationError.prototype instanceof SerializerError);
+    });
+
+    it('Its name is an SerializationError error', () => {
+        const error = new SerializationError();
+        assert.strictEqual(error.name, 'SerializationError');
+    });
+});

--- a/tests/Error/SerializerErrorTest.js
+++ b/tests/Error/SerializerErrorTest.js
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the serializerjs package.
+ *
+ * (c) HAIRCVT <tfidry@haircvt.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/* eslint-env mocha */
+
+import { assert } from 'chai';
+
+import SerializerError from './../../src/Error/SerializerError';
+
+/** @test {SerializationError} */
+describe('SerializationError', () => {
+    it('It is an Error', () => {
+        const error = new SerializerError();
+        assert.isTrue(error instanceof Error);
+    });
+
+    it('It captures the error message', () => {
+        const message = 'My message';
+        const error = new SerializerError(message);
+
+        assert.strictEqual(error.message, message);
+    });
+
+    it('An error without any message has an empty message', () => {
+        const error = new SerializerError();
+
+        assert.strictEqual(error.message, '');
+    });
+
+    it('It captures the error name', () => {
+        const error = new SerializerError();
+
+        assert.strictEqual(error.name, 'SerializerError');
+    });
+
+    it('It captures the error stack', () => {
+        const error = new SerializerError();
+
+        assert.isString(error.stack);
+        assert.isTrue(50 < error.stack.length);
+    });
+});

--- a/tests/Error/UnimplementedMethodError.js
+++ b/tests/Error/UnimplementedMethodError.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the serializerjs package.
+ *
+ * (c) HAIRCVT <tfidry@haircvt.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/* eslint-env mocha */
+
+import { assert } from 'chai';
+
+import SerializerError from './../../src/Error/SerializerError';
+import UnimplementedMethodError from './../../src/Error/UnimplementedMethodError';
+
+/** @test {SerializationError} */
+describe('SerializationError', () => {
+    it('It is a SerializerError', () => {
+        assert.isTrue(UnimplementedMethodError.prototype instanceof SerializerError);
+    });
+
+    it('Its name is an UnimplementedMethodError error', () => {
+        const error = new UnimplementedMethodError();
+        assert.strictEqual(error.name, 'UnimplementedMethodError');
+    });
+});

--- a/tests/Serializer/AbstractSerializerTest.js
+++ b/tests/Serializer/AbstractSerializerTest.js
@@ -20,9 +20,7 @@ describe('AbstractSerializer', () => {
      * @test {AbstractSerializer#constructor}
      */
     it('It implements the SerializerInterface interface', () => {
-        const abstractSerializer = new AbstractSerializer();
-
-        assert.isTrue(abstractSerializer instanceof SerializerInterface);
+        assert.isTrue(AbstractSerializer.prototype instanceof SerializerInterface);
     });
 
     /**

--- a/tests/Serializer/SerializerAwareTest.js
+++ b/tests/Serializer/SerializerAwareTest.js
@@ -13,15 +13,13 @@ import { assert } from 'chai';
 
 import SerializerAware from './../../src/Serializer/SerializerAware';
 import SerializerInterface from './../../src/Serializer/SerializerInterface';
-import UnimplementedSerializerMethodError from './../../src/Error/UnimplementedSerializerMethodError';
+import UnimplementedSerializerMethodError from './../../src/Error/UnimplementedMethodError';
 
 /** @test {SerializerAware} */
 describe('SerializerAware', () => {
     /** @test {SerializerAware#constructor} */
     it('It implements the SerializerInterface interface', () => {
-        const serializerAware = new SerializerAware();
-
-        assert.isTrue(serializerAware instanceof SerializerInterface);
+        assert.isTrue(SerializerAware.prototype instanceof SerializerInterface);
     });
 
     /** @test {SerializerAware#setSerializer} */

--- a/tests/Serializer/SerializerInterfaceTest.js
+++ b/tests/Serializer/SerializerInterfaceTest.js
@@ -12,7 +12,7 @@
 import { assert } from 'chai';
 
 import SerializerInterface from './../../src/Serializer/SerializerInterface';
-import UnimplementedSerializerMethodError from './../../src/Error/UnimplementedSerializerMethodError';
+import UnimplementedMethodError from './../../src/Error/UnimplementedMethodError';
 
 /** @test {SerializerInterface} */
 describe('SerializerInterface', () => {
@@ -25,9 +25,32 @@ describe('SerializerInterface', () => {
     it('As an interface, it should not implement anything', () => {
         const serializer = new SerializerInterface();
 
+        // Potential refactor
+        // @see https://github.com/chaijs/chai/issues/596
         assert.throw(serializer.deserialize, Error);
         assert.throw(serializer.serialize, Error);
         assert.throw(serializer.supportsDeserialize, Error);
         assert.throw(serializer.supportsSerialize, Error);
+
+        try {
+            serializer.deserialize();
+        } catch (error) {
+            assert.strictEqual(error.name, 'UnimplementedMethodError');
+        }
+        try {
+            serializer.serialize();
+        } catch (error) {
+            assert.strictEqual(error.name, 'UnimplementedMethodError');
+        }
+        try {
+            serializer.supportsDeserialize();
+        } catch (error) {
+            assert.strictEqual(error.name, 'UnimplementedMethodError');
+        }
+        try {
+            serializer.supportsSerialize();
+        } catch (error) {
+            assert.strictEqual(error.name, 'UnimplementedMethodError');
+        }
     });
 });

--- a/tests/Serializer/SerializerTest.js
+++ b/tests/Serializer/SerializerTest.js
@@ -26,7 +26,7 @@ import serializer from './../Fixtures/app';
 describe('Serializer', () => {
     /** @test {Serializer#constructor} */
     it('It implements the SerializerInterface interface', () => {
-        assert.instanceOf(serializer, SerializerInterface);
+        assert.isTrue(Serializer.prototype instanceof SerializerInterface);
     });
 
     it('It should have a reference of all the registered serializers', () => {
@@ -38,6 +38,17 @@ describe('Serializer', () => {
         assert.strictEqual(serializer._serializers.size, 4);
     });
 
+    it('Only serialiers can be registered', () => {
+        // Potential refactor
+        // @see https://github.com/chaijs/chai/issues/596
+        try {
+            const invalidSerializer = new Serializer(new Map([
+                ['myKey', {}],
+            ]));
+        } catch (error) {
+            assert.strictEqual(error.name, 'InvalidArgumentError');
+        }
+    });
 
     describe('It can use the StringSerializer', () => {
         it('It should be able to deserialize a string', () => {
@@ -167,5 +178,16 @@ describe('Serializer', () => {
             assert.isTrue(serializer.supportsSerialize(user));
             assert.deepEqual(serializer.serialize(user, null, 'oldApi'), rawUserOldApi);
         });
+    });
+
+    it('If no serializer is found, should throw an error', () => {
+        assert.isFalse(serializer.supportsDeserialize({}, 'Dummy'));
+        // Potential refactor
+        // @see https://github.com/chaijs/chai/issues/596
+        try {
+            serializer.deserialize({}, 'Dummy');
+        } catch (error) {
+            assert.strictEqual(error.name, 'SerializationError');
+        }
     });
 });


### PR DESCRIPTION
- Introduced `SerializerError` as root error
- Added tests for errors
- Renamed `UnexpectedTypeError` for a more appropriate name: `InvalidArgumentError`
- Renamed needlessly lenghty `UnimplementedSerializerMethodError` for `UnimplementedMethodError`
